### PR TITLE
chore(.gititnore): Ignore `.DS_Store`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# macOS File System
+.DS_Store


### PR DESCRIPTION
`.DS_Store` is a file created by macOS File System and this file can have a negative affection on the workflow on other OS, we should ignore that from git to prevent other problems.